### PR TITLE
Fix 1.11 .1.12 1.13 NoSuchMethodError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,18 +23,18 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.16.4-R0.1-SNAPSHOT</version>
+			<version>1.13.2-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.1.56.Final</version>
+			<version>4.1.25.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>com.mojang</groupId>
 			<artifactId>authlib</artifactId>
-			<version>2.1.28</version>
+			<version>1.5.25</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -70,13 +70,12 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<artifactSet>
+								<excludes>
+									<exclude>io.netty:netty-all</exclude>
+								</excludes>
+							</artifactSet>
 							<filters>
-								<filter>
-									<artifact>*:*</artifact>
-									<excludes>
-										<exclude>META-INF/CHANGES</exclude>
-									</excludes>
-								</filter>
 								<filter>
 									<artifact>*:*</artifact>
 									<excludes>

--- a/src/io/github/bananapuncher714/radioboard/BoardListener.java
+++ b/src/io/github/bananapuncher714/radioboard/BoardListener.java
@@ -1,5 +1,8 @@
 package io.github.bananapuncher714.radioboard;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.BlockFace;
@@ -18,6 +21,7 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.server.MapInitializeEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.map.MapView;
 import org.bukkit.util.Vector;
 
 import io.github.bananapuncher714.radioboard.api.DisplayInteract;
@@ -144,9 +148,20 @@ public class BoardListener implements Listener {
 	
 	@EventHandler
 	private void onMapInitializeEvent( MapInitializeEvent event ) {
-		short id = ( short ) event.getMap().getId();
-		if ( RadioBoard.getInstance().getPacketHandler().isMapRegistered( id ) ) {
-			event.getMap().getRenderers().clear();
+		MapView view = event.getMap();
+		try {
+			Method getId = view.getClass().getMethod( "getId" );
+			int id = 0;
+			try {
+				id = ( int ) getId.invoke( view );
+			} catch ( ClassCastException e) {
+				id = ( short ) getId.invoke( view );
+			}
+			if ( RadioBoard.getInstance().getPacketHandler().isMapRegistered( id ) ) {
+				event.getMap().getRenderers().clear();
+			}
+		} catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			e.printStackTrace();
 		}
 	}
 	

--- a/src/io/github/bananapuncher714/radioboard/implementation/v1_11_R1/NMSHandler.java
+++ b/src/io/github/bananapuncher714/radioboard/implementation/v1_11_R1/NMSHandler.java
@@ -1,6 +1,8 @@
 package io.github.bananapuncher714.radioboard.implementation.v1_11_R1;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -205,7 +207,13 @@ public class NMSHandler implements PacketHandler {
 	@Override
 	public void registerMap( int mapId ) {
 		registeredMaps[ mapId ] = true;
-		MapView view = Bukkit.getMap( ( short ) mapId );
+		MapView view = null;
+		try {
+			Method getMapMethod = Bukkit.class.getMethod( "getMap", short.class );
+			view = ( MapView ) getMapMethod.invoke( null, ( short ) mapId );
+		} catch ( NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e ) {
+			e.printStackTrace();
+		}
 		if ( view != null ) {
 			view.getRenderers().clear();
 		}

--- a/src/io/github/bananapuncher714/radioboard/implementation/v1_12_R1/NMSHandler.java
+++ b/src/io/github/bananapuncher714/radioboard/implementation/v1_12_R1/NMSHandler.java
@@ -1,6 +1,8 @@
 package io.github.bananapuncher714.radioboard.implementation.v1_12_R1;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -201,7 +203,13 @@ public class NMSHandler implements PacketHandler {
 	@Override
 	public void registerMap( int id ) {
 		maps[ id ] = true;
-		MapView view = Bukkit.getMap( ( short ) id );
+		MapView view = null;
+		try {
+			Method getMapMethod = Bukkit.class.getMethod( "getMap", short.class );
+			view = ( MapView ) getMapMethod.invoke( null, (short) id );
+		} catch ( NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e ) {
+			e.printStackTrace();
+		}
 		if ( view != null ) {
 			view.getRenderers().clear();
 		}


### PR DESCRIPTION
### Fix 1.11 .1.12 1.13 NoSuchMethodError
Pull request #8 has tested in 1.14.4 and 1.16.2, but when I was going to sort out and report the issue #9 , I used 1.12.2 to test and the server threw an error. The reason is Bukkit.getMap method used need a short as parameter, but since 1.13 Bukkit.getMap changed to need a int as parameter, MapView.getId was same problem, it used return a short but now it return int.

- [Bukkit.getMap in 1.11.2](https://helpch.at/docs/1.11.2/org/bukkit/Bukkit.html#getMap(short))
- [Bukkit.getMap in 1.16.4](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Bukkit.html#getMap(int))
- [MapView.getId in 1.11.2](https://helpch.at/docs/1.11.2/org/bukkit/map/MapView.html#getId())
- [MapView.getId in 1.16.4](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/map/MapView.html#getId())

This is my mistake, i am very sorry. In case, this time i tested it on both 1.11.2 1.12.2 1.16.4.
### pom.xml file changes

- Changed api version to 1.13.2 in pom.xml to keep same with plugin.yml
- exclude files in io.netty which has been included in server jar.